### PR TITLE
Fix impossible dmz_correct in dmz_lab

### DIFF
--- a/labs/dmz-lab/remote_ws/_bin/prestop
+++ b/labs/dmz-lab/remote_ws/_bin/prestop
@@ -1,4 +1,4 @@
 #!/bin/bash
 trap "echo Timed out; exit" SIGTERM
 nmap -n www.example.com
-wget 198.18.1.194 -T 3 -t 1
+wget 198.18.1.194:80 -T 3 -t 1


### PR DESCRIPTION
The difference between results.config and prestop script makes it impossible to get dmz_correct in dmz-lab.
https://github.com/mfthomps/Labtainers/blob/4100f1f56504984ef413a8110d1f89a2e0de6259/labs/dmz-lab/instr_config/results.config#L14
